### PR TITLE
Redesign homepage, enlarge About page photo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+*.tsbuildinfo
 *.local
 
 # Editor directories and files

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,5 @@
+# CLAUDE
+
 ## Purpose
 
 This file is read automatically by **Claude Code**. Rules here apply to all Claude Code sessions in this repository.

--- a/src/components/AboutPage/AboutPage.tsx
+++ b/src/components/AboutPage/AboutPage.tsx
@@ -19,14 +19,14 @@ const AboutPage = () => {
     <div>
       {/* Instructor */}
       <section className="flex flex-col md:flex-row gap-12 max-w-5xl mx-auto px-4 py-16">
-        <div className="md:w-2/5">
+        <div className="md:w-3/5">
           <img
             src="/assets/Sergio.png"
             alt="Sergio Ortiz"
             className="w-full"
           />
         </div>
-        <div className="md:w-3/5">
+        <div className="md:w-2/5">
           <h2 className="text-sm text-zinc-400 uppercase tracking-wider">Meet Your Instructor</h2>
           <h1 className="text-3xl font-bold mt-2">Sergio &ldquo;Coco&rdquo; Ortiz</h1>
           <p className="mt-6 text-zinc-300 leading-relaxed">{text.sergio}</p>

--- a/src/components/DisciplinePage.tsx
+++ b/src/components/DisciplinePage.tsx
@@ -1,26 +1,22 @@
 import { useParams, Link } from 'react-router-dom'
+import { disciplinesBySlug } from '../data/disciplines'
 
-interface DisciplineDetail {
-  name: string
-  description: string
+type DisciplineSlug = keyof typeof disciplinesBySlug
+type DisciplineDetail = (typeof disciplinesBySlug)[DisciplineSlug] & {
   history: string
   whatToExpect: string
 }
 
-const disciplineData: Record<string, DisciplineDetail> = {
+const disciplineData: Record<DisciplineSlug, DisciplineDetail> = {
   bjj: {
-    name: 'Brazilian Jiu-Jitsu',
-    description:
-      'Ground-based grappling focused on submissions, positional control, and leverage over strength.',
+    ...disciplinesBySlug.bjj,
     history:
       'Brazilian Jiu-Jitsu evolved from Kodokan Judo and Japanese jujutsu, refined by the Gracie family in Brazil throughout the 20th century. It gained worldwide recognition after Royce Gracie dominated the early UFC tournaments, proving that technique and leverage could overcome size and strength.',
     whatToExpect:
       'Classes focus on no-gi grappling. Positional drilling, live sparring (rolling), and technique instruction. You will learn guard passes, sweeps, submissions, and escapes. All experience levels train together with instruction scaled to your ability.',
   },
   'catch-wrestling': {
-    name: 'Catch Wrestling',
-    description:
-      'Aggressive, submission-oriented wrestling emphasizing pins, cranks, and dominant positioning.',
+    ...disciplinesBySlug['catch-wrestling'],
     history:
       'Catch-as-catch-can wrestling originated in Britain and became wildly popular in America through carnival and professional wrestling circuits in the late 1800s and early 1900s. It is the ancestor of modern professional wrestling but retains its roots as a legitimate combat grappling system.',
     whatToExpect:
@@ -30,7 +26,8 @@ const disciplineData: Record<string, DisciplineDetail> = {
 
 const DisciplinePage = () => {
   const { slug } = useParams<{ slug: string }>()
-  const discipline = slug ? disciplineData[slug] : undefined
+  const discipline =
+    slug && slug in disciplineData ? disciplineData[slug as DisciplineSlug] : undefined
 
   if (!discipline) {
     return (

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -1,25 +1,7 @@
 import { Link } from 'react-router-dom'
+import { disciplinesBySlug } from '../data/disciplines'
 
-interface Discipline {
-  name: string
-  slug: string
-  description: string
-}
-
-const disciplines: Discipline[] = [
-  {
-    name: 'Brazilian Jiu-Jitsu',
-    slug: 'bjj',
-    description:
-      'Ground-based grappling focused on submissions, positional control, and leverage over strength.',
-  },
-  {
-    name: 'Catch Wrestling',
-    slug: 'catch-wrestling',
-    description:
-      'Aggressive, submission-oriented wrestling emphasizing pins, cranks, and dominant positioning.',
-  },
-]
+const disciplines = Object.values(disciplinesBySlug)
 
 const HomePage = () => {
   return (

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -24,8 +24,16 @@ const disciplines: Discipline[] = [
 const HomePage = () => {
   return (
     <div>
+      {/* Hero */}
+      <section className="py-20 md:py-28 text-center px-4">
+        <h1 className="text-4xl md:text-6xl font-bold tracking-tight max-w-3xl mx-auto leading-tight">
+          Sharpen your grappling.{' '}
+          <span className="text-brand-red">Every Friday at noon.</span>
+        </h1>
+      </section>
+
       {/* Disciplines */}
-      <section className="py-12 px-4 max-w-5xl mx-auto">
+      <section className="border-t border-zinc-900 py-16 px-4 max-w-5xl mx-auto">
         <div className="grid grid-cols-1 md:grid-cols-2 gap-y-10 md:gap-x-12">
           {disciplines.map((d) => (
             <Link
@@ -42,14 +50,26 @@ const HomePage = () => {
         </div>
       </section>
 
-      {/* CTA */}
-      <section className="border-t border-zinc-900 py-12 text-center">
-        <Link
-          to="/schedule"
-          className="text-brand-red hover:text-white transition-colors font-semibold text-lg"
-        >
-          View Schedule &rarr;
-        </Link>
+      {/* Instructor teaser */}
+      <section className="border-t border-zinc-900 py-16 px-4">
+        <div className="max-w-3xl mx-auto flex items-center gap-8">
+          <img
+            src="/assets/Sergio.png"
+            alt="Sergio Ortiz"
+            className="w-24 h-24 object-cover rounded-full flex-shrink-0"
+          />
+          <div>
+            <p className="text-zinc-300 leading-relaxed">
+              Led by Sergio &ldquo;Coco&rdquo; Ortiz. Black belt in BJJ, 17 years on the mats, 22 years in law enforcement.
+            </p>
+            <Link
+              to="/about"
+              className="mt-3 inline-block text-brand-red hover:text-white transition-colors font-semibold text-sm uppercase tracking-widest"
+            >
+              Meet your instructor &rarr;
+            </Link>
+          </div>
+        </div>
       </section>
     </div>
   )

--- a/src/data/disciplines.ts
+++ b/src/data/disciplines.ts
@@ -1,0 +1,20 @@
+export interface BaseDiscipline {
+  name: string
+  slug: string
+  description: string
+}
+
+export const disciplinesBySlug = {
+  bjj: {
+    name: 'Brazilian Jiu-Jitsu',
+    slug: 'bjj',
+    description:
+      'Ground-based grappling focused on submissions, positional control, and leverage over strength.',
+  },
+  'catch-wrestling': {
+    name: 'Catch Wrestling',
+    slug: 'catch-wrestling',
+    description:
+      'Aggressive, submission-oriented wrestling emphasizing pins, cranks, and dominant positioning.',
+  },
+} as const satisfies Record<string, BaseDiscipline>


### PR DESCRIPTION
- Add bold hero tagline with brand-red accent
- Add instructor teaser with photo and link to About
- Keep discipline links (BJJ, Catch Wrestling)
- Remove redundant schedule callout and old CTA
- Increase About page photo ratio to 60/40

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prominent hero added: "Sharpen your grappling" with highlighted "Every Friday at noon".
  * Instructor teaser added to home with profile, bio, and "Meet your instructor →" link.

* **Style**
  * Adjusted instructor section layout for improved responsive balance.
  * Disciplines section now has a top border and increased vertical spacing; schedule CTA replaced by the instructor teaser.

* **Documentation**
  * Minor header added to project documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->