### PR TITLE
[codex] Make contact form the only public contact path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.env

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "node scripts/validate-contact-env.mjs && tsc -b && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"
   },

--- a/scripts/validate-contact-env.mjs
+++ b/scripts/validate-contact-env.mjs
@@ -1,0 +1,59 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+const rootDir = process.cwd()
+const envFiles = ['.env.local', '.env']
+
+function readEnvValue(key) {
+  const directValue = process.env[key]?.trim()
+
+  if (directValue) {
+    return directValue
+  }
+
+  for (const envFile of envFiles) {
+    const envPath = path.join(rootDir, envFile)
+
+    if (!fs.existsSync(envPath)) {
+      continue
+    }
+
+    const contents = fs.readFileSync(envPath, 'utf8')
+
+    for (const line of contents.split(/\r?\n/)) {
+      const trimmedLine = line.trim()
+
+      if (!trimmedLine || trimmedLine.startsWith('#')) {
+        continue
+      }
+
+      const separatorIndex = trimmedLine.indexOf('=')
+
+      if (separatorIndex === -1) {
+        continue
+      }
+
+      const candidateKey = trimmedLine.slice(0, separatorIndex).trim()
+
+      if (candidateKey !== key) {
+        continue
+      }
+
+      const rawValue = trimmedLine.slice(separatorIndex + 1).trim()
+      const normalizedValue = rawValue.replace(/^['"]|['"]$/g, '').trim()
+
+      if (normalizedValue) {
+        return normalizedValue
+      }
+    }
+  }
+
+  return ''
+}
+
+const accessKey = readEnvValue('VITE_WEB3FORMS_ACCESS_KEY')
+
+if (!accessKey) {
+  console.error('Missing VITE_WEB3FORMS_ACCESS_KEY. Configure the contact form before building or deploying.')
+  process.exit(1)
+}

--- a/src/components/ContactPage.tsx
+++ b/src/components/ContactPage.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react'
-import { siteDetails, inquiryHours, classSchedule } from '../data/site'
 import { isContactFormConfigured, submitContactForm } from '../lib/contact'
 
 const emptyForm = {
@@ -9,21 +8,6 @@ const emptyForm = {
 }
 
 const ContactPage = () => {
-  const featuredSession = classSchedule[0] ?? null
-  const contactHighlights = [
-    {
-      label: 'Current class',
-      value: featuredSession ? `${featuredSession.day} at ${featuredSession.time}` : 'Schedule TBD',
-    },
-    {
-      label: 'Location',
-      value: siteDetails.city,
-    },
-    {
-      label: 'Best for',
-      value: 'First-visit questions, schedule details, and training fit',
-    },
-  ]
   const [formData, setFormData] = useState(emptyForm)
   const [status, setStatus] = useState<'idle' | 'submitting' | 'success' | 'error'>('idle')
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
@@ -47,66 +31,23 @@ const ContactPage = () => {
       setErrorMessage(
         error instanceof Error
           ? error.message
-          : 'Something went wrong. Please try again or email us directly.',
+          : 'Something went wrong. Please try again later.',
       )
     }
   }
 
   return (
     <div className="page-shell pb-16 pt-14 sm:pt-16">
-      <div className="grid gap-8 lg:grid-cols-[0.9fr_1.1fr]">
-        <div className="border-t border-white/10 pt-6 md:pt-8">
-          <p className="eyebrow">Get in touch</p>
+      <div className="mx-auto max-w-2xl border-t border-white/10 pt-6 md:pt-8">
+        <div>
+          <p className="eyebrow">Message the club</p>
           <h1 className="mt-4 text-4xl font-semibold tracking-tight text-white sm:text-5xl">
             Reach out before your first Friday session.
           </h1>
-          <p className="mt-5 text-base leading-7 text-zinc-300">
+          <p className="mt-5 max-w-xl text-base leading-7 text-zinc-300">
             Ask about schedule details, what to wear, whether the class is a fit for your experience level, or anything else that helps you show up prepared.
           </p>
 
-          <div className="mt-8 grid gap-3">
-            {contactHighlights.map((item) => (
-              <div key={item.label} className="border-l border-white/15 pl-4">
-                <p className="text-[11px] uppercase tracking-[0.28em] text-zinc-500">{item.label}</p>
-                <p className="mt-3 text-sm leading-6 text-zinc-300">{item.value}</p>
-              </div>
-            ))}
-          </div>
-
-          <dl className="mt-8 space-y-6 text-sm text-zinc-300">
-            <div>
-              <dt className="uppercase tracking-[0.22em] text-zinc-500">Email</dt>
-              <dd className="mt-2">
-                <a href={`mailto:${siteDetails.email}`} className="transition-colors hover:text-brand-red">
-                  {siteDetails.email}
-                </a>
-              </dd>
-            </div>
-            <div>
-              <dt className="uppercase tracking-[0.22em] text-zinc-500">Phone</dt>
-              <dd className="mt-2">
-                <a href={`tel:${siteDetails.phone.replace(/[^+\d]/g, '')}`} className="transition-colors hover:text-brand-red">
-                  {siteDetails.phone}
-                </a>
-              </dd>
-            </div>
-            <div>
-              <dt className="uppercase tracking-[0.22em] text-zinc-500">Availability</dt>
-              <dd className="mt-2 space-y-1 text-zinc-400">
-                {inquiryHours.map((window) => (
-                  <p key={window}>{window}</p>
-                ))}
-              </dd>
-            </div>
-            <div>
-              <dt className="uppercase tracking-[0.22em] text-zinc-500">Location</dt>
-              <dd className="mt-2 text-zinc-400">{siteDetails.city}</dd>
-            </div>
-          </dl>
-        </div>
-
-        <div className="border-t border-white/10 pt-6 md:pt-8">
-          <p className="eyebrow">Message the club</p>
           {status === 'success' ? (
             <div className="mt-6 border-l-2 border-brand-red pl-5">
               <h2 className="text-2xl font-semibold text-white">Message received.</h2>
@@ -136,7 +77,7 @@ const ContactPage = () => {
                   value={formData.name}
                   onChange={handleChange}
                   required
-                  className="mt-3 w-full rounded-2xl border border-white/10 bg-black/40 px-4 py-3 text-white outline-none transition-colors focus:border-brand-red"
+                  className="mt-3 w-full rounded-2xl border border-white/20 bg-white/[0.03] px-4 py-3 text-white outline-none transition-colors focus:border-brand-red"
                 />
               </div>
 
@@ -151,7 +92,7 @@ const ContactPage = () => {
                   value={formData.email}
                   onChange={handleChange}
                   required
-                  className="mt-3 w-full rounded-2xl border border-white/10 bg-black/40 px-4 py-3 text-white outline-none transition-colors focus:border-brand-red"
+                  className="mt-3 w-full rounded-2xl border border-white/20 bg-white/[0.03] px-4 py-3 text-white outline-none transition-colors focus:border-brand-red"
                 />
               </div>
 
@@ -166,7 +107,7 @@ const ContactPage = () => {
                   onChange={handleChange}
                   required
                   rows={6}
-                  className="mt-3 w-full rounded-2xl border border-white/10 bg-black/40 px-4 py-3 text-white outline-none transition-colors focus:border-brand-red"
+                  className="mt-3 w-full rounded-2xl border border-white/20 bg-white/[0.03] px-4 py-3 text-white outline-none transition-colors focus:border-brand-red"
                 />
               </div>
 
@@ -177,14 +118,14 @@ const ContactPage = () => {
               <p aria-live="polite" className={`text-sm ${status === 'error' ? 'text-brand-red' : 'text-zinc-500'}`}>
                 {status === 'error' && errorMessage
                   ? errorMessage
-                  : 'We respond by email or phone after reviewing your message.'}
+                  : 'We will follow up after reviewing your message.'}
               </p>
             </form>
           ) : (
             <div className="mt-6 border-l border-white/15 pl-5">
-              <h2 className="text-2xl font-semibold text-white">Direct contact is available now.</h2>
+              <h2 className="text-2xl font-semibold text-white">The contact form is temporarily unavailable.</h2>
               <p className="mt-3 text-sm leading-7 text-zinc-300">
-                The embedded web form is not configured in this environment. Use the email or phone details on this page and we will get you the information you need for your first visit.
+                Please check back shortly when the form is available again.
               </p>
             </div>
           )}

--- a/src/components/ContactPage.tsx
+++ b/src/components/ContactPage.tsx
@@ -21,6 +21,10 @@ const normalizeContactErrorMessage = (error: unknown) => {
 }
 
 const ContactPage = () => {
+  if (!isContactFormConfigured) {
+    throw new Error('Missing VITE_WEB3FORMS_ACCESS_KEY. Configure the contact form before rendering ContactPage.')
+  }
+
   const [formData, setFormData] = useState(emptyForm)
   const [status, setStatus] = useState<'idle' | 'submitting' | 'success' | 'error'>('idle')
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
@@ -130,9 +134,7 @@ const ContactPage = () => {
                   : 'We will follow up after reviewing your message.'}
               </p>
             </form>
-          ) : (() => {
-            throw new Error('Missing VITE_WEB3FORMS_ACCESS_KEY. Configure the contact form before rendering ContactPage.')
-          })()}
+          ) : null}
         </div>
       </div>
     </div>

--- a/src/components/ContactPage.tsx
+++ b/src/components/ContactPage.tsx
@@ -7,6 +7,19 @@ const emptyForm = {
   message: '',
 }
 
+const normalizeContactErrorMessage = (error: unknown) => {
+  const fallbackMessage = 'Something went wrong. Please try again through the form in a moment.'
+
+  if (!(error instanceof Error)) {
+    return fallbackMessage
+  }
+
+  return error.message
+    .replace(/please email or call us directly\.?/gi, 'Please try again through the form shortly.')
+    .replace(/please try again or contact us directly\.?/gi, 'Please try again through the form shortly.')
+    .replace(/contact us directly/gi, 'use the form again')
+}
+
 const ContactPage = () => {
   const [formData, setFormData] = useState(emptyForm)
   const [status, setStatus] = useState<'idle' | 'submitting' | 'success' | 'error'>('idle')
@@ -28,11 +41,7 @@ const ContactPage = () => {
       setFormData(emptyForm)
     } catch (error) {
       setStatus('error')
-      setErrorMessage(
-        error instanceof Error
-          ? error.message
-          : 'Something went wrong. Please try again later.',
-      )
+      setErrorMessage(normalizeContactErrorMessage(error))
     }
   }
 
@@ -121,14 +130,9 @@ const ContactPage = () => {
                   : 'We will follow up after reviewing your message.'}
               </p>
             </form>
-          ) : (
-            <div className="mt-6 border-l border-white/15 pl-5">
-              <h2 className="text-2xl font-semibold text-white">The contact form is temporarily unavailable.</h2>
-              <p className="mt-3 text-sm leading-7 text-zinc-300">
-                Please check back shortly when the form is available again.
-              </p>
-            </div>
-          )}
+          ) : (() => {
+            throw new Error('Missing VITE_WEB3FORMS_ACCESS_KEY. Configure the contact form before rendering ContactPage.')
+          })()}
         </div>
       </div>
     </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -13,14 +13,9 @@ const Footer = () => {
           <div className="mx-auto">
             <h3 className="text-sm font-medium uppercase tracking-[0.25em] text-zinc-400">Contact</h3>
             <p className="mt-4 text-sm text-zinc-400">{siteDetails.city}</p>
-            <div className="mt-5 space-y-2 text-sm text-zinc-300">
-              <a href={`mailto:${siteDetails.email}`} className="block transition-colors hover:text-brand-red">
-                {siteDetails.email}
-              </a>
-              <a href={`tel:${siteDetails.phone.replace(/[^+\d]/g, '')}`} className="block transition-colors hover:text-brand-red">
-                {siteDetails.phone}
-              </a>
-            </div>
+            <Link to="/contact" className="mt-5 inline-block text-sm text-zinc-300 transition-colors hover:text-brand-red">
+              Use the contact form
+            </Link>
           </div>
 
           <div className="mx-auto">

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -19,16 +19,8 @@ const NavBar = () => {
   return (
     <nav className="fixed inset-x-0 top-0 z-50 border-b border-white/10 bg-black/80 backdrop-blur-xl">
       <div className="page-shell flex items-center justify-between py-3">
-        <Link to="/" className="flex items-center gap-3">
+        <Link to="/" className="flex items-center">
           <img src="/assets/crazy8logo.jpeg" alt={siteDetails.name} className="h-12 w-12 rounded-full" />
-          <div>
-            <p className="text-sm font-semibold uppercase tracking-[0.25em] text-white">
-              Crazy 8
-            </p>
-            <p className="text-xs uppercase tracking-[0.28em] text-zinc-400">
-              Friday 12:00 PM
-            </p>
-          </div>
         </Link>
 
         <div className="hidden items-center gap-8 md:flex">

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -8,8 +8,6 @@ export interface ClassSession {
 export const siteDetails = {
   name: 'Crazy 8 Grappling Club',
   city: 'San Marcos, Texas',
-  email: 'info@crazy8grappling.com',
-  phone: '(512) 555-0188',
   instructorName: 'Sergio "Coco" Ortiz',
   instructorSummary:
     'Black belt in BJJ with 17 years on the mats, 22 years in law enforcement, and a teaching style built around pressure, control, and practical grappling.',

--- a/src/lib/contact.ts
+++ b/src/lib/contact.ts
@@ -11,7 +11,7 @@ export const isContactFormConfigured = accessKey.length > 0
 
 export async function submitContactForm(values: ContactFormValues) {
   if (!isContactFormConfigured) {
-    throw new Error('The contact form is not configured yet. Please email or call us directly.')
+    throw new Error('The contact form is not configured yet. Please try again through the form shortly.')
   }
 
   const controller = new AbortController()
@@ -34,11 +34,11 @@ export async function submitContactForm(values: ContactFormValues) {
     })
   } catch (error) {
     if (error instanceof DOMException && error.name === 'AbortError') {
-      throw new Error('The contact request timed out. Please try again or contact us directly.')
+      throw new Error('The contact request timed out. Please try again through the form shortly.')
     }
 
     console.error('Contact form request failed', error)
-    throw new Error('There was a problem sending your message. Please try again or contact us directly.')
+    throw new Error('There was a problem sending your message. Please try again through the form shortly.')
   } finally {
     window.clearTimeout(timeoutId)
   }

--- a/src/lib/contact.ts
+++ b/src/lib/contact.ts
@@ -52,6 +52,10 @@ export async function submitContactForm(values: ContactFormValues) {
   }
 
   if (!response.ok || !data?.success) {
-    throw new Error(data?.message || 'Unable to send your message through the form right now. Please try again.')
+    console.error('Contact form provider rejected the request', {
+      status: response.status,
+      message: data?.message ?? null,
+    })
+    throw new Error('Unable to send your message through the form right now. Please try again.')
   }
 }

--- a/src/lib/contact.ts
+++ b/src/lib/contact.ts
@@ -52,6 +52,6 @@ export async function submitContactForm(values: ContactFormValues) {
   }
 
   if (!response.ok || !data?.success) {
-    throw new Error(data?.message || 'Unable to send your message right now. Please try again.')
+    throw new Error(data?.message || 'Unable to send your message through the form right now. Please try again.')
   }
 }


### PR DESCRIPTION
## Summary
- make the contact form the only public contact path
- remove public email and phone details from the contact page and footer
- simplify the contact page layout and remove the navbar text lockup

## Validation
- pnpm build
- pnpm lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Contact flow consolidated: direct-contact links removed; users are directed to and prompted to retry via the contact form.

* **Style**
  * Contact page redesigned to a centered, single-column layout with tightened helper text and updated input styling.
  * Header/footer simplified; home link reduced to icon-only display.

* **Chores**
  * Added .env to ignore list and a pre-build validation step to ensure contact form configuration is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->