### PR TITLE
[codex] Tighten homepage hero and route scrolling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
-import { BrowserRouter as Router, Route, Routes } from 'react-router-dom'
+import { useEffect } from 'react'
+import { BrowserRouter as Router, Route, Routes, useLocation } from 'react-router-dom'
 import NavBar from './components/NavBar/NavBar'
 import HomePage from './components/HomePage'
 import AboutPage from './components/AboutPage/AboutPage'
@@ -7,9 +8,20 @@ import SchedulePage from './components/SchedulePage/SchedulePage'
 import DisciplinePage from './components/DisciplinePage'
 import Footer from './components/Footer'
 
+function ScrollToTop() {
+  const { pathname } = useLocation()
+
+  useEffect(() => {
+    window.scrollTo({ top: 0, left: 0, behavior: 'auto' })
+  }, [pathname])
+
+  return null
+}
+
 function App() {
   return (
     <Router>
+      <ScrollToTop />
       <div className="min-h-screen">
         <NavBar />
         <main className="relative overflow-x-hidden pt-20 sm:pt-24">

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -4,14 +4,6 @@ import { classSchedule, siteDetails } from '../data/site'
 
 const HomePage = () => {
   const featuredSession = classSchedule.length > 0 ? classSchedule[0] : undefined
-  const featuredScheduleLabel = featuredSession
-    ? `${featuredSession.day} at ${featuredSession.time} in ${siteDetails.city}`
-    : 'Schedule TBD'
-  const highlights = [
-    { label: 'Lead Coach', value: siteDetails.instructorName },
-    { label: 'Location', value: siteDetails.city },
-    { label: 'Schedule', value: featuredScheduleLabel },
-  ]
 
   return (
     <div className="pb-16">
@@ -30,18 +22,6 @@ const HomePage = () => {
               <Link to="/contact" className="cta-primary">
                 Book a Visit
               </Link>
-              <p className="mt-4 text-sm uppercase tracking-[0.2em] text-zinc-500">
-                {featuredScheduleLabel}
-              </p>
-            </div>
-
-            <div className="mt-10 grid gap-4 sm:grid-cols-3">
-              {highlights.map((item) => (
-                <div key={item.label} className="border-l border-white/15 pl-4">
-                  <p className="text-[11px] uppercase tracking-[0.28em] text-zinc-500">{item.label}</p>
-                  <p className="mt-3 text-sm font-medium text-white">{item.value}</p>
-                </div>
-              ))}
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
- remove the extra homepage hero metadata strip and schedule subline
- add route-change scroll reset so contact links land at the top of the page

## Validation
- pnpm build
- pnpm lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed page scroll position to reset to the top when navigating between routes, improving the navigation experience.

* **Updates**
  * Removed the featured schedule label and highlights section from the homepage to streamline the page layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->