### PR TITLE
Refine homepage hero copy and footer logo layout

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -9,8 +9,8 @@ const Footer = () => {
   return (
     <footer className="border-t border-white/10 py-14">
       <div className="page-shell">
-        <div className="mx-auto grid max-w-2xl justify-center gap-x-24 gap-y-10 text-center md:grid-cols-2">
-          <div className="mx-auto">
+        <div className="mx-auto grid max-w-5xl items-center gap-10 text-center md:grid-cols-[1fr_auto_1fr] md:text-left">
+          <div className="mx-auto md:mx-0">
             <h3 className="text-sm font-medium uppercase tracking-[0.25em] text-zinc-400">Contact</h3>
             <p className="mt-4 text-sm text-zinc-400">{siteDetails.city}</p>
             <Link to="/contact" className="mt-5 inline-block text-sm text-zinc-300 transition-colors hover:text-brand-red">
@@ -18,7 +18,15 @@ const Footer = () => {
             </Link>
           </div>
 
-          <div className="mx-auto">
+          <Link to="/" className="mx-auto block w-full max-w-md transition-transform hover:scale-[1.01]">
+            <img
+              src="/assets/crazy8logo.jpeg"
+              alt={`${siteDetails.name} logo`}
+              className="mx-auto w-full"
+            />
+          </Link>
+
+          <div className="mx-auto md:mx-0 md:justify-self-end md:text-right">
             <h3 className="text-sm font-medium uppercase tracking-[0.25em] text-zinc-400">Explore</h3>
             <ul className="mt-4 space-y-3">
               <li>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -23,6 +23,9 @@ const Footer = () => {
               src="/assets/crazy8logo.jpeg"
               alt={`${siteDetails.name} logo`}
               className="mx-auto w-full"
+              loading="lazy"
+              decoding="async"
+              fetchPriority="low"
             />
           </Link>
 

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -12,10 +12,10 @@ const HomePage = () => {
           <div className="max-w-2xl">
             <p className="eyebrow">San Marcos Grappling Club</p>
             <h1 className="mt-5 text-4xl font-semibold leading-tight tracking-tight text-white sm:text-5xl lg:text-6xl">
-              Sharpen your grappling with pressure-first Friday training.
+              Build better grappling habits with focused Friday training.
             </h1>
             <p className="mt-6 max-w-xl text-base leading-7 text-zinc-300 sm:text-lg">
-              {siteDetails.name} is built for students who want technical no-gi instruction, harder positional pressure, and a clear path to more confident grappling.
+              {siteDetails.name} is built for students who want technical no-gi instruction, stronger positional pressure, and a clear path to more confident grappling.
             </p>
 
             <div className="mt-8">


### PR DESCRIPTION
## Summary
- revise the homepage hero copy to a more approachable Friday-training message
- tighten the supporting hero sentence around positional pressure
- redesign the footer so the logo is centered with Contact on the left and Explore on the right

## Testing
- pnpm build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Styling**
  * Redesigned footer layout for improved responsiveness: now a three-column arrangement with a centered logo link, refined alignment across screen sizes, and subtle hover scaling on the logo for better visual balance.

* **Content Updates**
  * Updated homepage hero copy to emphasize building better grappling habits and stronger positional pressure during focused Friday training.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->